### PR TITLE
feat: add initial csharp implementation

### DIFF
--- a/C#Imp/Error.cs
+++ b/C#Imp/Error.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace Fiskalizacija2 {
+    public class ValidationError : Exception {
+        public object? Value { get; }
+
+        public ValidationError(string message, object? value) : base(message) {
+            Value = value;
+        }
+
+        public override string ToString() {
+            if (Value == null) {
+                return $"ValidationError: {Message}";
+            }
+            var display = Value is string ? $"\"{Value}\"" : Value.ToString();
+            return $"ValidationError: {Message} (value: {display})";
+        }
+    }
+
+    public static class ErrorUtils {
+        public static ErrorWithMessage ParseError(Exception error) {
+            return new ErrorWithMessage {
+                Message = error.Message,
+                Thrown = error
+            };
+        }
+    }
+}

--- a/C#Imp/Fiskalizacija2.csproj
+++ b/C#Imp/Fiskalizacija2.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/C#Imp/FiskalizacijaClient.cs
+++ b/C#Imp/FiskalizacijaClient.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Fiskalizacija2 {
+    public class FiskalizacijaClient {
+        private readonly XmlSigner _signer;
+        private readonly FiskalizacijaOptions _options;
+
+        public FiskalizacijaClient(FiskalizacijaOptions options) {
+            _options = options ?? new FiskalizacijaOptions();
+            _signer = new XmlSigner(options);
+        }
+
+        private async Task<FiskalizacijaResult<TReq, TRes>> Execute<TReqData, TReq, TRes>(
+            TReqData zahtjev,
+            RequestConfig<TReqData, TReq, TRes> config
+        ) where TReq : SerializableRequest where TRes : ParsedResponse {
+            var result = new FiskalizacijaResult<TReq, TRes> { Success = false };
+            try {
+                var requestInstance = zahtjev is TReq existing ? existing : config.RequestFactory!(zahtjev);
+                result.ReqObject = requestInstance;
+                var signedXml = _signer.SignFiscalizationRequest(requestInstance.ToXmlString(), requestInstance.Id);
+                var soap = GenerateSoapEnvelope(signedXml);
+                result.SoapReqRaw = soap;
+                var (statusCode, data) = await HttpHelper.PostRequestAsync(soap, _options);
+                result.HttpStatusCode = statusCode;
+                result.SoapResRaw = data;
+                try {
+                    result.SoapResSignatureValid = XmlSigner.IsValidSignature(data);
+                } catch (Exception e) {
+                    result.SoapResSignatureValid = false;
+                    result.Error = ErrorUtils.ParseError(e);
+                }
+                if (config.ResponseFactory != null) {
+                    result.ResObject = config.ResponseFactory(data);
+                }
+                result.Success = result.Error == null;
+            }
+            catch (Exception ex) {
+                result.Error = ErrorUtils.ParseError(ex);
+            }
+            return result;
+        }
+
+        private string GenerateSoapEnvelope(string body, bool withXmlDec = true) {
+            var res = string.Empty;
+            if (withXmlDec) {
+                res += "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+            }
+            res += "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">";
+            res += "<soap:Body>";
+            res += body;
+            res += "</soap:Body>";
+            res += "</soap:Envelope>";
+            return res;
+        }
+    }
+}

--- a/C#Imp/HttpHelper.cs
+++ b/C#Imp/HttpHelper.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Fiskalizacija2 {
+    public static class HttpHelper {
+        public static async Task<(int statusCode, string data)> PostRequestAsync(string data, FiskalizacijaOptions options) {
+            var handler = new HttpClientHandler();
+            if (options.AllowSelfSigned) {
+                handler.ServerCertificateCustomValidationCallback = (req, cert, chain, errors) => true;
+            }
+            using var client = new HttpClient(handler);
+            client.Timeout = TimeSpan.FromMilliseconds(options.Timeout);
+            var request = new HttpRequestMessage(HttpMethod.Post, options.Service);
+            foreach (var header in options.Headers) {
+                request.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+            request.Content = new StringContent(data, Encoding.UTF8, "application/xml");
+            var response = await client.SendAsync(request);
+            var body = await response.Content.ReadAsStringAsync();
+            return ((int)response.StatusCode, body);
+        }
+    }
+}

--- a/C#Imp/README.md
+++ b/C#Imp/README.md
@@ -1,0 +1,7 @@
+# Fiskalizacija2 C# Implementation
+
+This folder contains an evolving C# port of the core `FiskalizacijaClient` from the
+original TypeScript project. It provides basic data structures, an XML signer,
+and utilities for SOAP envelope generation, HTTP communication, error handling
+and time formatting. Full XML model support and request/response parsing have
+not yet been implemented.

--- a/C#Imp/TimeUtils.cs
+++ b/C#Imp/TimeUtils.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Fiskalizacija2 {
+    public static class TimeUtils {
+        public static string GetCurrentDateTimeString() {
+            var now = DateTime.Now;
+            return $"{now:yyyy-MM-ddTHH:mm:ss}.{now:fff}0";
+        }
+    }
+}

--- a/C#Imp/Types.cs
+++ b/C#Imp/Types.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace Fiskalizacija2 {
+    public class ErrorWithMessage {
+        public string Message { get; set; } = string.Empty;
+        public object? Thrown { get; set; }
+    }
+
+    public class SigningOptions {
+        public string PrivateKey { get; set; } = string.Empty;
+        public string PublicCert { get; set; } = string.Empty;
+        public string? SignatureAlgorithm { get; set; }
+        public string? CanonicalizationAlgorithm { get; set; }
+        public string? DigestAlgorithm { get; set; }
+    }
+
+    public class FiskalizacijaOptions : SigningOptions {
+        public byte[]? Ca { get; set; }
+        public string Service { get; set; } = string.Empty;
+        public bool AllowSelfSigned { get; set; }
+        public int Timeout { get; set; } = 30000;
+        public Dictionary<string, string> Headers { get; set; } = new();
+    }
+
+    public interface IGreska {
+        string? Poruka { get; }
+    }
+
+    public class FiskalizacijaResult<TReq, TRes> {
+        public bool Success { get; set; }
+        public ErrorWithMessage? Error { get; set; }
+        public int? HttpStatusCode { get; set; }
+        public string? SoapReqRaw { get; set; }
+        public TReq? ReqObject { get; set; }
+        public string? SoapResRaw { get; set; }
+        public bool? SoapResSignatureValid { get; set; }
+        public TRes? ResObject { get; set; }
+    }
+
+    public interface SerializableRequest {
+        string ToXmlString();
+        string Id { get; }
+    }
+
+    public class OdgovorContent {
+        public bool PrihvacenZahtjev { get; set; }
+        public IGreska? Greska { get; set; }
+    }
+
+    public interface ParsedResponse {
+        OdgovorContent Odgovor { get; }
+    }
+
+    public class RequestConfig<TReqData, TReq, TRes>
+        where TReq : SerializableRequest
+        where TRes : ParsedResponse {
+        public Func<TReqData, TReq>? RequestFactory { get; set; }
+        public Func<string, TRes>? ResponseFactory { get; set; }
+        public string XPath { get; set; } = string.Empty;
+    }
+}

--- a/C#Imp/XmlSigner.cs
+++ b/C#Imp/XmlSigner.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Fiskalizacija2 {
+    public class XmlSigner {
+        public XmlSigner(FiskalizacijaOptions options) {
+            // TODO: load certificates and prepare signing configuration
+        }
+
+        public string SignFiscalizationRequest(string xml, string id) {
+            // TODO: implement signing of XML payload
+            return xml;
+        }
+
+        public static bool IsValidSignature(string xml) {
+            // TODO: implement signature validation
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- start C# port in new `C#Imp` folder
- add skeleton `FiskalizacijaClient` and supporting types
- include placeholder XML signer and README
- expand C# utilities with HTTP helper, error handling, timestamp formatting, and richer type definitions

## Testing
- `npm test`
- `dotnet build C#Imp/Fiskalizacija2.csproj` *(fails: dotnet not installed; apt repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68adaa7c954883308fadba3d337b77ab