### PR TITLE
Load PEM certificates and validate response signatures

### DIFF
--- a/src/fiskalizacija.ts
+++ b/src/fiskalizacija.ts
@@ -82,7 +82,10 @@ export class FiskalizacijaClient {
             result.soapResRaw = data;
 
             try {
-                result.soapResSignatureValid = XmlSigner.isValidSignature(result.soapResRaw);
+                result.soapResSignatureValid = XmlSigner.isValidSignature(
+                    result.soapResRaw,
+                    this.options.publicCert
+                );
             } catch (error) {
                 result.soapResSignatureValid = false;
                 result.error = parseError(error);

--- a/src/util/cert.ts
+++ b/src/util/cert.ts
@@ -1,7 +1,20 @@
-export function extractPemCertificate(pem: string | Buffer): string {
-    if (Buffer.isBuffer(pem)) {
-        pem = pem.toString("utf8");
+import { existsSync, readFileSync } from "node:fs";
+
+export function loadPem(pemOrPath: string | Buffer): string {
+    if (Buffer.isBuffer(pemOrPath)) {
+        return pemOrPath.toString("utf8");
     }
+    if (pemOrPath.includes("-----BEGIN")) {
+        return pemOrPath;
+    }
+    if (existsSync(pemOrPath)) {
+        return readFileSync(pemOrPath, "utf8");
+    }
+    return pemOrPath;
+}
+
+export function extractPemCertificate(pem: string | Buffer): string {
+    pem = loadPem(pem);
     const match = pem.match(/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s);
     if (match && match[0]) {
         return match[0].trim();
@@ -10,9 +23,7 @@ export function extractPemCertificate(pem: string | Buffer): string {
 }
 
 export function extractPemPrivateKey(pem: string | Buffer): string {
-    if (Buffer.isBuffer(pem)) {
-        pem = pem.toString("utf8");
-    }
+    pem = loadPem(pem);
     const match = pem.match(/-----BEGIN (?:RSA )?PRIVATE KEY-----(.*?)-----END (?:RSA )?PRIVATE KEY-----/s);
     if (match && match[0]) {
         return match[0].trim();

--- a/src/util/signing.ts
+++ b/src/util/signing.ts
@@ -68,15 +68,20 @@ export class XmlSigner {
             objects: [{ content: this.getXAdESContent(signatureId, signedPropertiesId, signingTime) }]
         });
 
-        // Add reference to the entire document
+        // Add reference to the entire document by ID
         sig.addReference({
+            uri: `#${referenceURI}`,
             xpath: `//*[@*[local-name()='id'] = '${referenceURI}']`,
             digestAlgorithm: this.options.digestAlgorithm,
-            transforms: ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"]
+            transforms: [
+                "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+                "http://www.w3.org/2001/10/xml-exc-c14n#"
+            ]
         });
 
-        // Add reference to the SignedProperties
+        // Add reference to the SignedProperties by ID
         sig.addReference({
+            uri: `#${signedPropertiesId}`,
             xpath: `//*[@Id='${signedPropertiesId}']`,
             type: "http://uri.etsi.org/01903#SignedProperties",
             digestAlgorithm: "http://www.w3.org/2001/04/xmlenc#sha256",

--- a/tests/util/signing.test.ts
+++ b/tests/util/signing.test.ts
@@ -38,6 +38,23 @@ describe("XmlSigner", () => {
 
             expect(signer).toBeDefined();
         });
+
+        it("should load keys and certificates from file paths", () => {
+            const keyPath = "/tmp/mock-private-key.pem";
+            const certPath = "/tmp/mock-public-cert.pem";
+            fs.writeFileSync(keyPath, mockPrivateKey);
+            fs.writeFileSync(certPath, mockPublicCert);
+
+            const signer = new XmlSigner({
+                privateKey: keyPath,
+                publicCert: certPath
+            });
+
+            expect(signer).toBeDefined();
+
+            fs.unlinkSync(keyPath);
+            fs.unlinkSync(certPath);
+        });
     });
 
     describe("generateId", () => {


### PR DESCRIPTION
## Summary
- load PEM certificates/keys from options, allowing file paths
- sign fiscalization requests by reference ID
- verify response signatures against the configured public certificate

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adb35e4a7c8330b9597b225a6738d1