### PR TITLE
feat: expose generic send helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Metode za slanje zahtjeva su:
 - `evidentirajNaplatu(IEvidentirajNaplatu)`
 - `evidentirajOdbijanje(IEvidentirajOdbijanje)`
 - `evidentirajIsporukuZaKojuNijeIzdanERacun(IEvidentirajIsporukuZaKojuNijeIzdanERacun)`
+- `sendAsync(zahtjev | objektZahtjeva, config)` – generička metoda za slanje bilo kojeg zahtjeva
 
 Sve metode vraćaju `FiskalizacijaResult` objekt koji sadrži:
 
@@ -74,6 +75,17 @@ const client = new FiskalizacijaClient({
     publicCert: fs.readFileSync('path/to/publicCert.pem'),
 })
 ````
+
+### sendAsync
+
+```typescript
+const zahtjev = getEvidentirajERacunZahtjev('I', getERacunFromUbl(ublDocument));
+const result = await client.sendAsync(zahtjev, {
+    RequestClass: EvidentirajERacunZahtjev,
+    ResponseClass: EvidentirajERacunOdgovor,
+    xpath: "/soapenv:Envelope/soapenv:Body/efis:EvidentirajERacunOdgovor"
+});
+```
 
 ### EvidentirajERacun
 

--- a/src/fiskalizacija.ts
+++ b/src/fiskalizacija.ts
@@ -103,6 +103,21 @@ export class FiskalizacijaClient {
         return result;
     }
 
+    sendAsync<TReqData, TReq extends SerializableRequest, TRes extends ParsedResponse>(
+        zahtjev: TReq,
+        config: RequestConfig<TReqData, TReq, TRes>
+    ): Promise<FiskalizacijaResult<TReq, TRes>>;
+    sendAsync<TReqData, TReq extends SerializableRequest, TRes extends ParsedResponse>(
+        zahtjev: TReqData,
+        config: RequestConfig<TReqData, TReq, TRes>
+    ): Promise<FiskalizacijaResult<TReq, TRes>>;
+    async sendAsync<TReqData, TReq extends SerializableRequest, TRes extends ParsedResponse>(
+        zahtjev: TReq | TReqData,
+        config: RequestConfig<TReqData, TReq, TRes>
+    ): Promise<FiskalizacijaResult<TReq, TRes>> {
+        return this.execute(zahtjev, config);
+    }
+
     async evidentirajERacun(zahtjev: IEvidentirajERacunZahtjev | EvidentirajERacunZahtjev) {
         return this.execute(zahtjev, {
             RequestClass: EvidentirajERacunZahtjev,


### PR DESCRIPTION
## Summary
- add public `sendAsync` wrapper that allows sending arbitrary fiskalizacija requests
- document new `sendAsync` helper in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adb35db41c8330ae7158d4fd5a96f8