### PR TITLE
feat(csharp): port builders and models

### DIFF
--- a/C#Imp/Builders/UblBuilder.cs
+++ b/C#Imp/Builders/UblBuilder.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Xml.Linq;
+using Fiskalizacija2.Models.Xml;
+using Fiskalizacija2.Utils;
+
+namespace Fiskalizacija2.Builders
+{
+    public static class UblBuilder
+    {
+        public static ERacun GetERacunFromUbl(string xml)
+        {
+            return XmlUtils.UsingXmlDocument(xml, doc =>
+            {
+                var root = doc.Root ?? throw new Exception("Missing root element");
+                var type = root.Name.LocalName;
+                if (type != "Invoice" && type != "CreditNote")
+                {
+                    throw new Exception($"Expected 'Invoice' or 'CreditNote' as root element, got '{type}'");
+                }
+                return ERacun.FromUblElement(root, type);
+            });
+        }
+
+        public static Racun GetRacunFromUbl(string xml)
+        {
+            return XmlUtils.UsingXmlDocument(xml, doc =>
+            {
+                var root = doc.Root ?? throw new Exception("Missing root element");
+                var type = root.Name.LocalName;
+                if (type != "Invoice" && type != "CreditNote")
+                {
+                    throw new Exception($"Expected 'Invoice' or 'CreditNote' as root element, got '{type}'");
+                }
+                return Racun.FromUblElement(root, type);
+            });
+        }
+    }
+}

--- a/C#Imp/Builders/ZahtjeviBuilder.cs
+++ b/C#Imp/Builders/ZahtjeviBuilder.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using Fiskalizacija2.Models.Xml;
+
+namespace Fiskalizacija2.Builders
+{
+    public static class ZahtjeviBuilder
+    {
+        public static EvidentirajERacunZahtjev GetEvidentirajERacunZahtjev(string vrsta, ERacun eracun)
+        {
+            return GetEvidentirajERacunZahtjev(vrsta, new[] { eracun });
+        }
+
+        public static EvidentirajERacunZahtjev GetEvidentirajERacunZahtjev(string vrsta, IEnumerable<ERacun> eracun)
+        {
+            return new EvidentirajERacunZahtjev
+            {
+                Id = Guid.NewGuid().ToString(),
+                Zaglavlje = new ZaglavljeFiskalizacija
+                {
+                    DatumVrijemeSlanja = TimeUtils.GetCurrentDateTimeString(),
+                    VrstaERacuna = vrsta
+                },
+                ERacun = new List<ERacun>(eracun)
+            };
+        }
+
+        public static EvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev GetEvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev(IEnumerable<Racun> racun)
+        {
+            return new EvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev
+            {
+                Id = Guid.NewGuid().ToString(),
+                Zaglavlje = new ZaglavljeFiskalizacija
+                {
+                    DatumVrijemeSlanja = TimeUtils.GetCurrentDateTimeString(),
+                    VrstaERacuna = "IR"
+                },
+                Racun = new List<Racun>(racun)
+            };
+        }
+
+        public static EvidentirajNaplatuZahtjev GetEvidentirajNaplatuZahtjev(IEnumerable<Naplata> naplata)
+        {
+            return new EvidentirajNaplatuZahtjev
+            {
+                Id = Guid.NewGuid().ToString(),
+                Zaglavlje = new ZaglavljeFiskalizacija
+                {
+                    DatumVrijemeSlanja = TimeUtils.GetCurrentDateTimeString()
+                },
+                Naplata = new List<Naplata>(naplata)
+            };
+        }
+
+        public static EvidentirajOdbijanjeZahtjev GetEvidentirajOdbijanjeZahtjev(IEnumerable<Odbijanje> odbijanje)
+        {
+            return new EvidentirajOdbijanjeZahtjev
+            {
+                Id = Guid.NewGuid().ToString(),
+                Zaglavlje = new ZaglavljeFiskalizacija
+                {
+                    DatumVrijemeSlanja = TimeUtils.GetCurrentDateTimeString()
+                },
+                Odbijanje = new List<Odbijanje>(odbijanje)
+            };
+        }
+    }
+}

--- a/C#Imp/CertUtils.cs
+++ b/C#Imp/CertUtils.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Fiskalizacija2.Utils
+{
+    public static class CertUtils
+    {
+        private static readonly Regex CertRegex = new Regex("-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----", RegexOptions.Singleline);
+        private static readonly Regex KeyRegex = new Regex("-----BEGIN (?:RSA )?PRIVATE KEY-----(.*?)-----END (?:RSA )?PRIVATE KEY-----", RegexOptions.Singleline);
+
+        public static string ExtractPemCertificate(string pem)
+        {
+            var match = CertRegex.Match(pem);
+            if (match.Success)
+            {
+                return match.Value.Trim();
+            }
+            throw new ArgumentException("Invalid PEM certificate format");
+        }
+
+        public static string ExtractPemCertificate(byte[] pem)
+        {
+            return ExtractPemCertificate(Encoding.UTF8.GetString(pem));
+        }
+
+        public static string ExtractPemPrivateKey(string pem)
+        {
+            var match = KeyRegex.Match(pem);
+            if (match.Success)
+            {
+                return match.Value.Trim();
+            }
+            throw new ArgumentException("Invalid PEM private key format");
+        }
+
+        public static string ExtractPemPrivateKey(byte[] pem)
+        {
+            return ExtractPemPrivateKey(Encoding.UTF8.GetString(pem));
+        }
+    }
+}

--- a/C#Imp/Models/FiskalizacijaService.cs
+++ b/C#Imp/Models/FiskalizacijaService.cs
@@ -1,0 +1,8 @@
+namespace Fiskalizacija2.Models
+{
+    public static class FiskalizacijaService
+    {
+        public const string Test = "https://cis.porezna-uprava.hr:8511/FiskalizacijaService";
+        public const string Prod = "https://cis.porezna-uprava.hr:8509/FiskalizacijaService";
+    }
+}

--- a/C#Imp/Models/Xml/FiskalizacijaModels.cs
+++ b/C#Imp/Models/Xml/FiskalizacijaModels.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Xml.Linq;
+using Fiskalizacija2.Utils;
+
+namespace Fiskalizacija2.Models.Xml
+{
+    public class ZaglavljeFiskalizacija
+    {
+        public string DatumVrijemeSlanja { get; set; } = string.Empty;
+        public string VrstaERacuna { get; set; } = string.Empty;
+
+        public string ToXmlString()
+        {
+            var res = "<efis:Zaglavlje>";
+            res += $"<efis:datumVrijemeSlanja>{XmlUtils.XmlEscape(DatumVrijemeSlanja)}</efis:datumVrijemeSlanja>";
+            res += $"<efis:vrstaERacuna>{XmlUtils.XmlEscape(VrstaERacuna)}</efis:vrstaERacuna>";
+            res += "</efis:Zaglavlje>";
+            return res;
+        }
+
+        public static ZaglavljeFiskalizacija FromXmlElement(XElement el)
+        {
+            return new ZaglavljeFiskalizacija
+            {
+                DatumVrijemeSlanja = XmlUtils.GetElementContent(el, "efis:datumVrijemeSlanja"),
+                VrstaERacuna = XmlUtils.GetElementContent(el, "efis:vrstaERacuna")
+            };
+        }
+    }
+
+    public class ERacun
+    {
+        public string BrojDokumenta { get; set; } = string.Empty;
+        public string DatumIzdavanja { get; set; } = string.Empty;
+        public string VrstaDokumenta { get; set; } = string.Empty;
+        public string ValutaERacuna { get; set; } = string.Empty;
+        public bool IndikatorKopije { get; set; }
+
+        public string ToXmlString()
+        {
+            var res = "<efis:ERacun>";
+            res += $"<efis:brojDokumenta>{XmlUtils.XmlEscape(BrojDokumenta)}</efis:brojDokumenta>";
+            res += $"<efis:datumIzdavanja>{XmlUtils.XmlEscape(DatumIzdavanja)}</efis:datumIzdavanja>";
+            res += $"<efis:vrstaDokumenta>{XmlUtils.XmlEscape(VrstaDokumenta)}</efis:vrstaDokumenta>";
+            res += $"<efis:valutaERacuna>{XmlUtils.XmlEscape(ValutaERacuna)}</efis:valutaERacuna>";
+            res += $"<efis:indikatorKopije>{(IndikatorKopije ? "true" : "false")}</efis:indikatorKopije>";
+            res += "</efis:ERacun>";
+            return res;
+        }
+
+        public static ERacun FromUblElement(XElement el, string type)
+        {
+            XNamespace cbc = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2";
+            return new ERacun
+            {
+                BrojDokumenta = el.Element(cbc + "ID")?.Value ?? string.Empty,
+                DatumIzdavanja = el.Element(cbc + "IssueDate")?.Value ?? string.Empty,
+                VrstaDokumenta = type,
+                ValutaERacuna = el.Element(cbc + "DocumentCurrencyCode")?.Value ?? string.Empty,
+                IndikatorKopije = false
+            };
+        }
+    }
+
+    public class Racun
+    {
+        public string BrojDokumenta { get; set; } = string.Empty;
+
+        public static Racun FromUblElement(XElement el, string type)
+        {
+            XNamespace cbc = "urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2";
+            return new Racun
+            {
+                BrojDokumenta = el.Element(cbc + "ID")?.Value ?? string.Empty
+            };
+        }
+    }
+
+    public class EvidentirajERacunZahtjev : SerializableRequest
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public ZaglavljeFiskalizacija Zaglavlje { get; set; } = new();
+        public List<ERacun> ERacun { get; set; } = new();
+
+        public string ToXmlString()
+        {
+            var res = $"<efis:EvidentirajERacunZahtjev efis:id=\"{XmlUtils.XmlEscape(Id)}\">";
+            res += Zaglavlje.ToXmlString();
+            foreach (var e in ERacun)
+            {
+                res += e.ToXmlString();
+            }
+            res += "</efis:EvidentirajERacunZahtjev>";
+            return res;
+        }
+    }
+
+    public class EvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev : SerializableRequest
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public ZaglavljeFiskalizacija Zaglavlje { get; set; } = new();
+        public List<Racun> Racun { get; set; } = new();
+
+        public string ToXmlString()
+        {
+            var res = $"<efis:EvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev efis:id=\"{XmlUtils.XmlEscape(Id)}\">";
+            res += Zaglavlje.ToXmlString();
+            foreach (var r in Racun)
+            {
+                // Placeholder - racun serialization not implemented
+            }
+            res += "</efis:EvidentirajIsporukuZaKojuNijeIzdanERacunZahtjev>";
+            return res;
+        }
+    }
+
+    public class EvidentirajNaplatuZahtjev : SerializableRequest
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public ZaglavljeFiskalizacija Zaglavlje { get; set; } = new();
+        public List<Naplata> Naplata { get; set; } = new();
+
+        public string ToXmlString()
+        {
+            var res = $"<efis:EvidentirajNaplatuZahtjev efis:id=\"{XmlUtils.XmlEscape(Id)}\">";
+            res += Zaglavlje.ToXmlString();
+            res += "</efis:EvidentirajNaplatuZahtjev>";
+            return res;
+        }
+    }
+
+    public class EvidentirajOdbijanjeZahtjev : SerializableRequest
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public ZaglavljeFiskalizacija Zaglavlje { get; set; } = new();
+        public List<Odbijanje> Odbijanje { get; set; } = new();
+
+        public string ToXmlString()
+        {
+            var res = $"<efis:EvidentirajOdbijanjeZahtjev efis:id=\"{XmlUtils.XmlEscape(Id)}\">";
+            res += Zaglavlje.ToXmlString();
+            res += "</efis:EvidentirajOdbijanjeZahtjev>";
+            return res;
+        }
+    }
+
+    public class Naplata { }
+    public class Odbijanje { }
+}

--- a/C#Imp/README.md
+++ b/C#Imp/README.md
@@ -1,14 +1,8 @@
 # Fiskalizacija2 C# Implementation
 
-
-This folder contains an evolving C# port of the core `FiskalizacijaClient` from the
-original TypeScript project. It provides basic data structures, an XML signer,
-and utilities for SOAP envelope generation, HTTP communication, error handling
-and time formatting. Full XML model support and request/response parsing have
-not yet been implemented.
-=======
-This folder contains an initial C# port of the core `FiskalizacijaClient` from the
-original TypeScript project. It provides basic data structures and a skeleton
-implementation for signing and SOAP envelope generation. HTTP communication and
-full XML model support have not yet been implemented.
-
+This folder contains an evolving C# port of the original TypeScript project.
+It now includes builders for generating request objects, basic XML models,
+certificate and XML utility helpers, an XML signer, HTTP helpers, error
+handling and time formatting. The implementation is still incomplete and
+does not yet cover the entire XML specification or full request/response
+parsing.

--- a/C#Imp/XmlUtils.cs
+++ b/C#Imp/XmlUtils.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security;
+using System.Xml.Linq;
+
+namespace Fiskalizacija2.Utils
+{
+    public static class XmlUtils
+    {
+        public static string XmlEscape(string? val)
+        {
+            return SecurityElement.Escape(val) ?? string.Empty;
+        }
+
+        public static T UsingXmlDocument<T>(string xml, Func<XDocument, T> fn)
+        {
+            var doc = XDocument.Parse(xml);
+            return fn(doc);
+        }
+
+        public static string GetElementContent(XElement parent, string tag)
+        {
+            var el = parent.Element(GetXName(parent, tag));
+            if (el == null)
+            {
+                throw new Exception($"Element '{tag}' not found in '{parent.Name}'");
+            }
+            return el.Value;
+        }
+
+        public static string? GetOptionalElementContent(XElement parent, string tag)
+        {
+            var el = parent.Element(GetXName(parent, tag));
+            return el?.Value;
+        }
+
+        public static T ExtractElement<T>(XElement parent, string tag, Func<XElement, T> fn)
+        {
+            var el = parent.Element(GetXName(parent, tag));
+            if (el == null)
+            {
+                throw new Exception($"Element '{tag}' not found in '{parent.Name}'");
+            }
+            return fn(el);
+        }
+
+        public static List<T> ExtractElements<T>(XElement parent, string tag, Func<XElement, T> fn)
+        {
+            return parent.Elements(GetXName(parent, tag)).Select(fn).ToList();
+        }
+
+        public static string GetAttributeValue(XElement el, string name)
+        {
+            var attr = el.Attribute(name);
+            if (attr == null)
+            {
+                throw new Exception($"Attribute '{name}' not found in element '{el.Name}'");
+            }
+            return attr.Value;
+        }
+
+        public static string? GetOptionalAttributeValue(XElement el, string name)
+        {
+            return el.Attribute(name)?.Value;
+        }
+
+        private static XName GetXName(XElement parent, string tag)
+        {
+            if (tag.Contains(':'))
+            {
+                var parts = tag.Split(':');
+                var ns = parent.GetNamespaceOfPrefix(parts[0]);
+                return ns + parts[1];
+            }
+            return tag;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add C# builders to construct requests from UBL and raw data
- port API and XML models for Fiskalizacija service
- implement certificate parsing and XML helper utilities in C#

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb35ce4088330ac711a0541fc7a81