### PR TITLE
refactor: cleanup types and options

### DIFF
--- a/C#Imp/Types.cs
+++ b/C#Imp/Types.cs
@@ -17,11 +17,8 @@ namespace Fiskalizacija2 {
 
     public class FiskalizacijaOptions : SigningOptions {
         public byte[]? Ca { get; set; }
-        public string Service { get; set; } = string.Empty;
         public bool AllowSelfSigned { get; set; }
-
-    public class FiskalizacijaOptions {
-
+        public string Service { get; set; } = string.Empty;
         public int Timeout { get; set; } = 30000;
         public Dictionary<string, string> Headers { get; set; } = new();
     }
@@ -32,7 +29,6 @@ namespace Fiskalizacija2 {
 
     public class FiskalizacijaResult<TReq, TRes> {
         public bool Success { get; set; }
-
         public ErrorWithMessage? Error { get; set; }
         public int? HttpStatusCode { get; set; }
         public string? SoapReqRaw { get; set; }
@@ -40,15 +36,6 @@ namespace Fiskalizacija2 {
         public string? SoapResRaw { get; set; }
         public bool? SoapResSignatureValid { get; set; }
         public TRes? ResObject { get; set; }
-
-        public TReq? ReqObject { get; set; }
-        public TRes? ResObject { get; set; }
-        public int? HttpStatusCode { get; set; }
-        public bool? SoapResSignatureValid { get; set; }
-        public string? SoapReqRaw { get; set; }
-        public string? SoapResRaw { get; set; }
-        public Exception? Error { get; set; }
-
     }
 
     public interface SerializableRequest {
@@ -56,17 +43,11 @@ namespace Fiskalizacija2 {
         string Id { get; }
     }
 
-    public interface ParsedResponse {
-        OdgovorContent Odgovor { get; }
-    }
-
-
     public class OdgovorContent {
         public bool PrihvacenZahtjev { get; set; }
         public IGreska? Greska { get; set; }
     }
 
-
     public interface ParsedResponse {
         OdgovorContent Odgovor { get; }
     }
@@ -74,15 +55,9 @@ namespace Fiskalizacija2 {
     public class RequestConfig<TReqData, TReq, TRes>
         where TReq : SerializableRequest
         where TRes : ParsedResponse {
-        public Func<TReqData, TReq>? RequestFactory { get; set; }
-        public Func<string, TRes>? ResponseFactory { get; set; }
-
-    public class RequestConfig<TReqData, TReq, TRes>
-        where TReq : SerializableRequest
-        where TRes : ParsedResponse {
         public Func<TReqData, TReq> RequestFactory { get; set; } = default!;
-        public Func<string, TRes> ResponseFactory { get; set; } = default!;
-
+        public Func<string, TRes>? ResponseFactory { get; set; }
         public string XPath { get; set; } = string.Empty;
     }
 }
+


### PR DESCRIPTION
## Summary
- remove duplicated type definitions
- ensure FiskalizacijaOptions derives from SigningOptions
- streamline generic result and request config models

## Testing
- `npm test`
- `dotnet build C#Imp/Fiskalizacija2.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc010c83c8330b5c33c616d9366d3