### PR TITLE
Add response models and SOAP deserialization for C# client

### DIFF
--- a/C#Imp/Models/Xml/FiskalizacijaResponses.cs
+++ b/C#Imp/Models/Xml/FiskalizacijaResponses.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Xml.Linq;
+using Fiskalizacija2.Utils;
+
+namespace Fiskalizacija2.Models.Xml
+{
+    internal static class OdgovorParser
+    {
+        public static OdgovorContent Parse(XElement el)
+        {
+            var ns = el.Name.Namespace;
+            var odgovor = new OdgovorContent
+            {
+                IdZahtjeva = el.Element(ns + "idZahtjeva")?.Value ?? string.Empty,
+                PrihvacenZahtjev = (el.Element(ns + "prihvacenZahtjev")?.Value ?? string.Empty)
+                    .Equals("true", StringComparison.OrdinalIgnoreCase)
+            };
+            var greskaEl = el.Element(ns + "Greska");
+            if (greskaEl != null)
+            {
+                odgovor.Greska = new GreskaContent
+                {
+                    Sifra = greskaEl.Element(ns + "sifra")?.Value ?? string.Empty,
+                    RedniBrojZapisa = greskaEl.Element(ns + "redniBrojZapisa")?.Value ?? string.Empty,
+                    Opis = greskaEl.Element(ns + "opis")?.Value ?? string.Empty
+                };
+            }
+            return odgovor;
+        }
+    }
+
+    public class EvidentirajERacunOdgovor : ParsedResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DatumVrijemeSlanja { get; set; } = string.Empty;
+        public OdgovorContent Odgovor { get; set; } = new();
+
+        public static EvidentirajERacunOdgovor FromXmlElement(XElement el)
+        {
+            var ns = el.Name.Namespace;
+            return new EvidentirajERacunOdgovor
+            {
+                Id = el.Attribute(ns + "id")?.Value ?? string.Empty,
+                DatumVrijemeSlanja = el.Element(ns + "datumVrijemeSlanja")?.Value ?? string.Empty,
+                Odgovor = OdgovorParser.Parse(el.Element(ns + "Odgovor")!)
+            };
+        }
+    }
+
+    public class EvidentirajNaplatuOdgovor : ParsedResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DatumVrijemeSlanja { get; set; } = string.Empty;
+        public OdgovorContent Odgovor { get; set; } = new();
+
+        public static EvidentirajNaplatuOdgovor FromXmlElement(XElement el)
+        {
+            var ns = el.Name.Namespace;
+            return new EvidentirajNaplatuOdgovor
+            {
+                Id = el.Attribute(ns + "id")?.Value ?? string.Empty,
+                DatumVrijemeSlanja = el.Element(ns + "datumVrijemeSlanja")?.Value ?? string.Empty,
+                Odgovor = OdgovorParser.Parse(el.Element(ns + "Odgovor")!)
+            };
+        }
+    }
+
+    public class EvidentirajOdbijanjeOdgovor : ParsedResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DatumVrijemeSlanja { get; set; } = string.Empty;
+        public OdgovorContent Odgovor { get; set; } = new();
+
+        public static EvidentirajOdbijanjeOdgovor FromXmlElement(XElement el)
+        {
+            var ns = el.Name.Namespace;
+            return new EvidentirajOdbijanjeOdgovor
+            {
+                Id = el.Attribute(ns + "id")?.Value ?? string.Empty,
+                DatumVrijemeSlanja = el.Element(ns + "datumVrijemeSlanja")?.Value ?? string.Empty,
+                Odgovor = OdgovorParser.Parse(el.Element(ns + "Odgovor")!)
+            };
+        }
+    }
+
+    public class EvidentirajIsporukuZaKojuNijeIzdanERacunOdgovor : ParsedResponse
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DatumVrijemeSlanja { get; set; } = string.Empty;
+        public OdgovorContent Odgovor { get; set; } = new();
+
+        public static EvidentirajIsporukuZaKojuNijeIzdanERacunOdgovor FromXmlElement(XElement el)
+        {
+            var ns = el.Name.Namespace;
+            return new EvidentirajIsporukuZaKojuNijeIzdanERacunOdgovor
+            {
+                Id = el.Attribute(ns + "id")?.Value ?? string.Empty,
+                DatumVrijemeSlanja = el.Element(ns + "datumVrijemeSlanja")?.Value ?? string.Empty,
+                Odgovor = OdgovorParser.Parse(el.Element(ns + "Odgovor")!)
+            };
+        }
+    }
+}

--- a/C#Imp/Types.cs
+++ b/C#Imp/Types.cs
@@ -1,13 +1,17 @@
 using System;
 using System.Collections.Generic;
+using System.Xml.Linq;
 
-namespace Fiskalizacija2 {
-    public class ErrorWithMessage {
+namespace Fiskalizacija2
+{
+    public class ErrorWithMessage
+    {
         public string Message { get; set; } = string.Empty;
         public object? Thrown { get; set; }
     }
 
-    public class SigningOptions {
+    public class SigningOptions
+    {
         public string PrivateKey { get; set; } = string.Empty;
         public string PublicCert { get; set; } = string.Empty;
         public string? SignatureAlgorithm { get; set; }
@@ -15,24 +19,49 @@ namespace Fiskalizacija2 {
         public string? DigestAlgorithm { get; set; }
     }
 
-    public class FiskalizacijaOptions : SigningOptions {
+    public class FiskalizacijaOptions : SigningOptions
+    {
         public byte[]? Ca { get; set; }
         public string Service { get; set; } = string.Empty;
         public bool AllowSelfSigned { get; set; }
-
-    public class FiskalizacijaOptions {
-
         public int Timeout { get; set; } = 30000;
         public Dictionary<string, string> Headers { get; set; } = new();
     }
 
-    public interface IGreska {
+    public interface IGreska
+    {
         string? Poruka { get; }
     }
 
-    public class FiskalizacijaResult<TReq, TRes> {
-        public bool Success { get; set; }
+    public class GreskaContent : IGreska
+    {
+        public string Sifra { get; set; } = string.Empty;
+        public string RedniBrojZapisa { get; set; } = string.Empty;
+        public string Opis { get; set; } = string.Empty;
+        public string? Poruka => Opis;
+    }
 
+    public class OdgovorContent
+    {
+        public string IdZahtjeva { get; set; } = string.Empty;
+        public bool PrihvacenZahtjev { get; set; }
+        public GreskaContent? Greska { get; set; }
+    }
+
+    public interface SerializableRequest
+    {
+        string ToXmlString();
+        string Id { get; }
+    }
+
+    public interface ParsedResponse
+    {
+        OdgovorContent Odgovor { get; }
+    }
+
+    public class FiskalizacijaResult<TReq, TRes>
+    {
+        public bool Success { get; set; }
         public ErrorWithMessage? Error { get; set; }
         public int? HttpStatusCode { get; set; }
         public string? SoapReqRaw { get; set; }
@@ -40,49 +69,15 @@ namespace Fiskalizacija2 {
         public string? SoapResRaw { get; set; }
         public bool? SoapResSignatureValid { get; set; }
         public TRes? ResObject { get; set; }
-
-        public TReq? ReqObject { get; set; }
-        public TRes? ResObject { get; set; }
-        public int? HttpStatusCode { get; set; }
-        public bool? SoapResSignatureValid { get; set; }
-        public string? SoapReqRaw { get; set; }
-        public string? SoapResRaw { get; set; }
-        public Exception? Error { get; set; }
-
-    }
-
-    public interface SerializableRequest {
-        string ToXmlString();
-        string Id { get; }
-    }
-
-    public interface ParsedResponse {
-        OdgovorContent Odgovor { get; }
-    }
-
-
-    public class OdgovorContent {
-        public bool PrihvacenZahtjev { get; set; }
-        public IGreska? Greska { get; set; }
-    }
-
-
-    public interface ParsedResponse {
-        OdgovorContent Odgovor { get; }
     }
 
     public class RequestConfig<TReqData, TReq, TRes>
         where TReq : SerializableRequest
-        where TRes : ParsedResponse {
-        public Func<TReqData, TReq>? RequestFactory { get; set; }
-        public Func<string, TRes>? ResponseFactory { get; set; }
-
-    public class RequestConfig<TReqData, TReq, TRes>
-        where TReq : SerializableRequest
-        where TRes : ParsedResponse {
+        where TRes : ParsedResponse
+    {
         public Func<TReqData, TReq> RequestFactory { get; set; } = default!;
-        public Func<string, TRes> ResponseFactory { get; set; } = default!;
-
+        public Func<XElement, TRes> ResponseFactory { get; set; } = default!;
         public string XPath { get; set; } = string.Empty;
     }
 }
+


### PR DESCRIPTION
## Summary
- Add typed response models for fiscalization endpoints with `FromXmlElement` parsers
- Parse SOAP responses in `FiskalizacijaClient` using XPath and new `RequestConfig`
- Extend core types with error/response structures

## Testing
- `npm test`
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc013a5448330a5ece06a5b6ad8de